### PR TITLE
Added metrics support (using Codahale metrics).

### DIFF
--- a/btm/pom.xml
+++ b/btm/pom.xml
@@ -69,6 +69,13 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.codahale.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${codahale.metrics.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/btm/src/main/java/bitronix/tm/Configuration.java
+++ b/btm/src/main/java/bitronix/tm/Configuration.java
@@ -77,6 +77,7 @@ public class Configuration implements Service {
     private volatile String resourceConfigurationFilename;
     private volatile boolean conservativeJournaling;
     private volatile String jdbcProxyFactoryClass;
+    private volatile String metricsFactoryClass;
 
     protected Configuration() {
         try {
@@ -125,6 +126,7 @@ public class Configuration implements Service {
             resourceConfigurationFilename = getString(properties, "bitronix.tm.resource.configuration", null);
             conservativeJournaling = getBoolean(properties, "bitronix.tm.conservativeJournaling", false);
             jdbcProxyFactoryClass = getString(properties, "bitronix.tm.jdbcProxyFactoryClass", "auto");
+            metricsFactoryClass = getString(properties, "bitronix.tm.metricsFactoryClass", "auto");
         } catch (IOException ex) {
             throw new InitializationException("error loading configuration", ex);
         }
@@ -683,6 +685,24 @@ public class Configuration implements Service {
         this.jdbcProxyFactoryClass = jdbcProxyFactoryClass;
     }
 
+    /**
+     * Get the factory class for creating metrics instances.
+     * The default value is "auto", set it to "none" if you don't want metrics.
+     *
+     * @return the name of the factory class
+     */
+    public String getMetricsFactoryClass() {
+        return metricsFactoryClass;
+    }
+
+    /**
+     * Set the name of the factory class for creating metrics instances.
+     *
+     * @param metricsFactoryClass the name of the metrics factory class
+     */
+    public void setMetricsFactoryClass(String metricsFactoryClass) {
+        this.metricsFactoryClass = metricsFactoryClass;
+    }
 
     /**
      * {@link bitronix.tm.resource.ResourceLoader} configuration file name. {@link bitronix.tm.resource.ResourceLoader}

--- a/btm/src/main/java/bitronix/tm/metric/CodahaleMetrics.java
+++ b/btm/src/main/java/bitronix/tm/metric/CodahaleMetrics.java
@@ -1,0 +1,75 @@
+package bitronix.tm.metric;
+
+import bitronix.tm.TransactionManagerServices;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * CodahaleMetrics - com.codahale.metrics based Metrics implementation.
+ * <p/>
+ * It may report the cummulated metrics to both the current log or platform JMX server.
+ *
+ * @author Vlad Mihalcea
+ */
+public class CodahaleMetrics implements Metrics {
+
+    private final static Logger log = LoggerFactory.getLogger(CodahaleMetrics.class);
+
+    private final String domain;
+
+    private final MetricRegistry metricRegistry;
+    private final Slf4jReporter logReporter;
+    private final JmxReporter jmxReporter;
+
+    public CodahaleMetrics(String domain) {
+        this.domain = domain;
+        this.metricRegistry = new MetricRegistry();
+        this.logReporter = Slf4jReporter
+                .forRegistry(metricRegistry)
+                .outputTo(log)
+                .build();
+        if (!TransactionManagerServices.getConfiguration().isDisableJmx()) {
+            jmxReporter = JmxReporter
+                    .forRegistry(metricRegistry)
+                    .inDomain(domain)
+                    .build();
+        } else {
+            jmxReporter = null;
+        }
+    }
+
+    public CodahaleMetrics(Class<?> clazz, String uniqueName) {
+        this(MetricRegistry.name(clazz, uniqueName));
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void updateHistogram(String name, long value) {
+        metricRegistry.histogram(name).update(value);
+    }
+
+    public void updateTimer(String name, long value, TimeUnit timeUnit) {
+        metricRegistry.timer(name).update(value, timeUnit);
+    }
+
+    public void start() {
+        logReporter.start(5, TimeUnit.MINUTES);
+        if (jmxReporter != null) {
+            jmxReporter.start();
+        }
+    }
+
+    public void stop() {
+        logReporter.stop();
+        if (jmxReporter != null) {
+            jmxReporter.stop();
+        }
+    }
+}

--- a/btm/src/main/java/bitronix/tm/metric/CodahaleMetricsFactory.java
+++ b/btm/src/main/java/bitronix/tm/metric/CodahaleMetricsFactory.java
@@ -1,0 +1,17 @@
+package bitronix.tm.metric;
+
+/**
+ * CodahaleMetricsFactory - com.codahale.metrics based MetricsFactory implementation.
+ *
+ * @author Vlad Mihalcea
+ */
+public class CodahaleMetricsFactory implements MetricsFactory {
+
+    public Metrics metrics(String domain) {
+        return new CodahaleMetrics(domain);
+    }
+
+    public Metrics metrics(Class<?> clazz, String uniqueName) {
+        return new CodahaleMetrics(clazz, uniqueName);
+    }
+}

--- a/btm/src/main/java/bitronix/tm/metric/Metrics.java
+++ b/btm/src/main/java/bitronix/tm/metric/Metrics.java
@@ -1,0 +1,46 @@
+package bitronix.tm.metric;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Metrics - This interface defines a metrics basic behavior. This is required to isolate Bitronix from
+ * external Metrics dependencies.
+ *
+ * @author Vlad Mihalcea
+ */
+public interface Metrics extends Serializable {
+
+    /**
+     * Each metrics must define the unique domain it represents.
+     *
+     * @return metrics domain
+     */
+    String getDomain();
+
+    /**
+     * Update the given histogram
+     *
+     * @param name  histogram name
+     * @param value histogram instant value
+     */
+    void updateHistogram(String name, long value);
+
+    /**
+     * Update the given timer
+     *
+     * @param name  timer name
+     * @param value timer instant value
+     */
+    void updateTimer(String name, long value, TimeUnit timeUnit);
+
+    /**
+     * Start metrics reporting.
+     */
+    void start();
+
+    /**
+     * Stop metrics reporting.
+     */
+    void stop();
+}

--- a/btm/src/main/java/bitronix/tm/metric/MetricsAware.java
+++ b/btm/src/main/java/bitronix/tm/metric/MetricsAware.java
@@ -1,0 +1,21 @@
+package bitronix.tm.metric;
+
+/**
+ * MetricsAware - Interface to obtaining the current associated Metrics
+ *
+ * @author Vlad Mihalcea
+ */
+public interface MetricsAware {
+
+    /**
+     * Initialize and bind a metrics to the current object.
+     */
+    void initializeMetrics();
+
+    /**
+     * Get the current object metrics.
+     *
+     * @return current object metrics.
+     */
+    Metrics getMetrics();
+}

--- a/btm/src/main/java/bitronix/tm/metric/MetricsFactory.java
+++ b/btm/src/main/java/bitronix/tm/metric/MetricsFactory.java
@@ -1,0 +1,92 @@
+package bitronix.tm.metric;
+
+import bitronix.tm.TransactionManagerServices;
+import bitronix.tm.internal.BitronixRuntimeException;
+import bitronix.tm.utils.ClassLoaderUtils;
+
+/**
+ * MetricsFactory - Factory for Metrics instances.
+ * <p/>
+ * By default (the "auto" mode) it tries to locate the Codahale metrics registry, and therefore the Instance will
+ * reference a CodahaleMetricsFactory instance.
+ * <p/>
+ * If you choose the "none" mode, you won;t get any MetricsFactory.
+ * <p/>
+ * If you choose a custom factory class name, then you may use your own Metrics implementation.
+ *
+ * @author Vlad Mihalcea
+ */
+public interface MetricsFactory {
+
+    /**
+     * Instance resolving utility.
+     */
+    public static class Instance {
+
+        /* Classes should use MetricsFactory.INSTANCE to access the factory */
+        static MetricsFactory INSTANCE = Initializer.initialize(
+                TransactionManagerServices.getConfiguration().getMetricsFactoryClass());
+
+        /**
+         * Check if there is any initialized instance.
+         *
+         * @return is any instance available.
+         */
+        public static boolean exists() {
+            return INSTANCE != null;
+        }
+
+        /**
+         * Get the initialized instance.
+         *
+         * @return the initialized instance.
+         */
+        public static MetricsFactory get() {
+            return INSTANCE;
+        }
+    }
+
+    /**
+     * Get the domain related metrics.
+     *
+     * @param domain domain
+     * @return domain related metrics
+     */
+    Metrics metrics(String domain);
+
+    /**
+     * Get a Class bound domain metrics, embedding an uniqueName.
+     *
+     * @param clazz      class as the metrics domain context
+     * @param uniqueName unique name to ensure domain uniqueness
+     * @return domain related metrics
+     */
+    Metrics metrics(Class<?> clazz, String uniqueName);
+
+    /**
+     * Initializer class used to initialize the factory.
+     */
+    class Initializer {
+        static MetricsFactory initialize(String metricFactoryClass) {
+            if ("none".equals(metricFactoryClass)) {
+                return null;
+            }
+            if ("auto".equals(metricFactoryClass)) {
+                try {
+                    ClassLoaderUtils.loadClass("com.codahale.metrics.MetricRegistry");
+                    return new CodahaleMetricsFactory();
+                } catch (ClassNotFoundException cnfe) {
+                    //DO NOTHING
+                }
+            } else if (!metricFactoryClass.isEmpty()) {
+                try {
+                    Class<?> clazz = ClassLoaderUtils.loadClass(metricFactoryClass);
+                    return (MetricsFactory) clazz.newInstance();
+                } catch (Exception ex) {
+                    throw new BitronixRuntimeException("error initializing MetricsFactory", ex);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/btm/src/main/java/bitronix/tm/resource/common/ResourceBean.java
+++ b/btm/src/main/java/bitronix/tm/resource/common/ResourceBean.java
@@ -15,6 +15,11 @@
  */
 package bitronix.tm.resource.common;
 
+import bitronix.tm.metric.Metrics;
+import bitronix.tm.metric.MetricsAware;
+import bitronix.tm.metric.MetricsFactory;
+import bitronix.tm.utils.ManagementRegistrar;
+
 import java.io.Serializable;
 import java.util.Properties;
 
@@ -25,7 +30,7 @@ import java.util.Properties;
  * @author Ludovic Orban
  */
 @SuppressWarnings("serial")
-public abstract class ResourceBean implements Serializable {
+public abstract class ResourceBean implements Serializable, MetricsAware {
 
     private volatile String className;
     private volatile String uniqueName;
@@ -48,6 +53,8 @@ public abstract class ResourceBean implements Serializable {
     private volatile boolean ignoreRecoveryFailures = false;
 
     private volatile transient int createdResourcesCounter;
+
+    private volatile transient Metrics metrics;
 
     /**
      * Initialize all properties with their default values.
@@ -361,5 +368,23 @@ public abstract class ResourceBean implements Serializable {
      */
     public int incCreatedResourcesCounter() {
         return this.createdResourcesCounter++;
+    }
+
+    /**
+     * Initialize a resource metrics, using the class and the unique name to build the metrics domain.
+     */
+    public void initializeMetrics() {
+        if (metrics == null && MetricsFactory.Instance.exists()) {
+            metrics = MetricsFactory.Instance.get()
+                    .metrics(getClass(), ManagementRegistrar.makeValidName(getUniqueName()));
+        }
+    }
+
+    /**
+     * Get the current associated metrics.
+     * @return current associated metrics.
+     */
+    public Metrics getMetrics() {
+        return metrics;
     }
 }

--- a/btm/src/main/java/bitronix/tm/resource/jdbc/PoolingDataSource.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/PoolingDataSource.java
@@ -86,6 +86,10 @@ public class PoolingDataSource extends ResourceBean implements DataSource, XARes
             buildXAPool();
             this.jmxName = "bitronix.tm:type=JDBC,UniqueName=" + ManagementRegistrar.makeValidName(getUniqueName());
             ManagementRegistrar.register(jmxName, this);
+            initializeMetrics();
+            if (getMetrics() != null) {
+                getMetrics().start();
+            }
         } catch (Exception ex) {
             throw new ResourceConfigurationException("cannot create JDBC datasource named " + getUniqueName(), ex);
         }
@@ -355,6 +359,9 @@ public class PoolingDataSource extends ResourceBean implements DataSource, XARes
 
         ManagementRegistrar.unregister(jmxName);
         jmxName = null;
+        if (getMetrics() != null) {
+            getMetrics().stop();
+        }
 
         ResourceRegistrar.unregister(this);
     }

--- a/btm/src/test/java/bitronix/tm/ConfigurationTest.java
+++ b/btm/src/test/java/bitronix/tm/ConfigurationTest.java
@@ -98,7 +98,7 @@ public class ConfigurationTest extends TestCase {
                 " jndiTransactionSynchronizationRegistryName=java:comp/TransactionSynchronizationRegistry," +
                 " jndiUserTransactionName=java:comp/UserTransaction, journal=disk," +
                 " logPart1Filename=target/btm1.tlog, logPart2Filename=target/btm2.tlog, maxLogSizeInMb=2," +
-                " resourceConfigurationFilename=null, serverId=null, skipCorruptedLogs=false, synchronousJmxRegistration=false," +
+                " metricsFactoryClass=auto, resourceConfigurationFilename=null, serverId=null, skipCorruptedLogs=false, synchronousJmxRegistration=false," +
                 " warnAboutZeroResourceTransaction=true]";
 
         assertEquals(expectation, new Configuration().toString());

--- a/btm/src/test/java/bitronix/tm/metric/MetricsFactoryTest.java
+++ b/btm/src/test/java/bitronix/tm/metric/MetricsFactoryTest.java
@@ -1,0 +1,32 @@
+package bitronix.tm.metric;
+
+import junit.framework.TestCase;
+
+/**
+ * MetricsFactoryTest - MetricsFactory Test
+ *
+ * @author Vlad Mihalcea
+ */
+public class MetricsFactoryTest extends TestCase {
+
+    public void testInitialize() {
+
+        MetricsFactory metricsFactory;
+
+        metricsFactory = MetricsFactoryTestUtil.defaultInitialize();
+        assertEquals(CodahaleMetricsFactory.class, metricsFactory.getClass());
+        assertTrue(MetricsFactory.Instance.exists());
+        assertEquals(metricsFactory.getClass(), MetricsFactory.Instance.get().getClass());
+
+        metricsFactory = MetricsFactoryTestUtil.initialize(MockitoMetricsFactory.class.getName());
+        assertTrue(MetricsFactory.Instance.exists());
+        assertEquals(MockitoMetricsFactory.class, metricsFactory.getClass());
+
+        metricsFactory = MetricsFactoryTestUtil.initialize("none");
+        assertNull(metricsFactory);
+    }
+
+    protected void tearDown() {
+        MetricsFactoryTestUtil.defaultInitialize();
+    }
+}

--- a/btm/src/test/java/bitronix/tm/metric/MetricsFactoryTestUtil.java
+++ b/btm/src/test/java/bitronix/tm/metric/MetricsFactoryTestUtil.java
@@ -1,0 +1,34 @@
+package bitronix.tm.metric;
+
+import bitronix.tm.TransactionManagerServices;
+
+/**
+ * MetricsFactoryTestUtil - MetricsFactory Test Utilities
+ *
+ * @author Vlad Mihalcea
+ */
+public class MetricsFactoryTestUtil {
+
+    /**
+     * Initialize the MetricsFactory instance with a different metricFactoryClass.
+     *
+     * @param metricFactoryClass MetricsFactory class
+     * @return MetricsFactory
+     */
+    public static MetricsFactory initialize(String metricFactoryClass) {
+        MetricsFactory.Instance.INSTANCE = MetricsFactory.Initializer.initialize(
+                metricFactoryClass);
+        return MetricsFactory.Instance.get();
+    }
+
+    /**
+     * Initialize the MetricsFactory instance with the default metricFactoryClass.
+     *
+     * @return MetricsFactory
+     */
+    public static MetricsFactory defaultInitialize() {
+        MetricsFactory.Instance.INSTANCE = MetricsFactory.Initializer.initialize(
+                TransactionManagerServices.getConfiguration().getMetricsFactoryClass());
+        return MetricsFactory.Instance.get();
+    }
+}

--- a/btm/src/test/java/bitronix/tm/metric/MockitoMetricsFactory.java
+++ b/btm/src/test/java/bitronix/tm/metric/MockitoMetricsFactory.java
@@ -1,0 +1,25 @@
+package bitronix.tm.metric;
+
+import org.mockito.Mockito;
+
+/**
+ * MockitoMetricsFactory - MetricsFactory for Mockito
+ *
+ * @author Vlad Mihalcea
+ */
+public class MockitoMetricsFactory implements MetricsFactory {
+
+    private MetricsFactory mockMetricsFactory = Mockito.mock(MetricsFactory.class);
+
+    public MetricsFactory getMockMetricsFactory() {
+        return mockMetricsFactory;
+    }
+
+    public Metrics metrics(String domain) {
+        return mockMetricsFactory.metrics(domain);
+    }
+
+    public Metrics metrics(Class<?> clazz, String uniqueName) {
+        return mockMetricsFactory.metrics(clazz, uniqueName);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
     <properties>
         <java.version>1.5</java.version>
         <spring.version>3.2.4.RELEASE</spring.version>
+        <codahale.metrics.version>3.0.1</codahale.metrics.version>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -180,6 +182,14 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.codahale.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${codahale.metrics.version}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Added CodaHale Metrics support
Added PoolingDataSource connection wait time metric
Added PoolingDataSource in-use-connections histogram metric

Refactored the in-use-connections logic since previous code review, please check its logic out.
Basically it should tell how many connections are in use at any given time, for building an accurate histogram.
My current solution is based on subtracting: totalPoolSize - availablePoolSize.
