### PR TITLE
Ensure that both Connection and XAConnection objects are closed.

### DIFF
--- a/btm/src/main/java/bitronix/tm/resource/jdbc/JdbcPooledConnection.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/JdbcPooledConnection.java
@@ -153,10 +153,15 @@ public class JdbcPooledConnection extends AbstractXAResourceHolder implements St
 
         poolingDataSource.unregister(this);
 
-        connection.close();
-        xaConnection.close();
-
-        poolingDataSource.fireOnDestroy(connection);
+        try {
+            connection.close();
+        } finally {
+            try {
+                xaConnection.close();
+            } finally {
+                poolingDataSource.fireOnDestroy(connection);
+            }
+        }
     }
 
     public RecoveryXAResourceHolder createRecoveryXAResourceHolder() {
@@ -271,10 +276,10 @@ public class JdbcPooledConnection extends AbstractXAResourceHolder implements St
         // Increment the usage count
         usageCount++;
 
-        // Only transition to STATE_ACCESSIBLE on the first usage.  If we're not sharing 
+        // Only transition to STATE_ACCESSIBLE on the first usage.  If we're not sharing
         // connections (default behavior) usageCount is always 1 here, so this transition
         // will always occur (current behavior unchanged).  If we _are_ sharing connections,
-        // and this is _not_ the first usage, it is valid for the state to already be 
+        // and this is _not_ the first usage, it is valid for the state to already be
         // STATE_ACCESSIBLE.  Calling setState() with STATE_ACCESSIBLE when the state is
         // already STATE_ACCESSIBLE fails the sanity check in AbstractXAStatefulHolder.
         // Even if the connection is shared (usageCount > 1), if the state was STATE_NOT_ACCESSIBLE

--- a/btm/src/main/java/bitronix/tm/resource/jms/JmsPooledConnection.java
+++ b/btm/src/main/java/bitronix/tm/resource/jms/JmsPooledConnection.java
@@ -68,7 +68,7 @@ public class JmsPooledConnection extends AbstractXAStatefulHolder implements Jms
         this.xaConnection = connection;
         this.lastReleaseDate = new Date(MonotonicClock.currentTimeMillis());
         addStateChangeEventListener(new JmsPooledConnectionStateChangeListener());
-        
+
         if (LrcXAConnectionFactory.class.getName().equals(poolingConnectionFactory.getClassName())) {
             if (log.isDebugEnabled()) { log.debug("emulating XA for resource " + poolingConnectionFactory.getUniqueName() + " - changing twoPcOrderingPosition to ALWAYS_LAST_POSITION"); }
             poolingConnectionFactory.setTwoPcOrderingPosition(Scheduler.ALWAYS_LAST_POSITION);
@@ -77,7 +77,7 @@ public class JmsPooledConnection extends AbstractXAStatefulHolder implements Jms
             if (log.isDebugEnabled()) { log.debug("emulating XA for resource " + poolingConnectionFactory.getUniqueName() + " - changing useTmJoin to true"); }
             poolingConnectionFactory.setUseTmJoin(true);
         }
-        
+
         this.jmxName = "bitronix.tm:type=JMS,UniqueName=" + ManagementRegistrar.makeValidName(poolingConnectionFactory.getUniqueName()) + ",Id=" + poolingConnectionFactory.incCreatedResourcesCounter();
         ManagementRegistrar.register(jmxName, this);
     }
@@ -100,9 +100,12 @@ public class JmsPooledConnection extends AbstractXAStatefulHolder implements Jms
         if (xaConnection != null) {
             poolingConnectionFactory.unregister(this);
             setState(STATE_CLOSED);
-            xaConnection.close();
+            try {
+                xaConnection.close();
+            } finally {
+                xaConnection = null;
+            }
         }
-        xaConnection = null;
     }
 
     public List<XAResourceHolder> getXAResourceHolders() {


### PR DESCRIPTION
With Oracle, the XAConnection holds the physical database connection and a number of other caches which we need to release.

Also ensure that the XAConnection is set to null after closing a JmsPooledConnection.
