### PR TITLE
Add a new configuration option for connection test timeout.

### DIFF
--- a/btm/src/main/java/bitronix/tm/resource/jdbc/PoolingDataSource.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/PoolingDataSource.java
@@ -62,6 +62,7 @@ public class PoolingDataSource extends ResourceBean implements DataSource, XARes
 
     private volatile String testQuery;
     private volatile boolean enableJdbc4ConnectionTest;
+    private volatile int connectionTestTimeout;
     private volatile int preparedStatementCacheSize = 0;
     private volatile String isolationLevel;
     private volatile String cursorHoldability;
@@ -158,6 +159,37 @@ public class PoolingDataSource extends ResourceBean implements DataSource, XARes
      */
     public boolean isEnableJdbc4ConnectionTest() {
         return enableJdbc4ConnectionTest;
+    }
+
+    /**
+     * Determines how many seconds the connection test logic
+     * will wait for a response from the database.
+     * @param connectionTestTimeout
+     */
+    public void setConnectionTestTimeout(int connectionTestTimeout) {
+        this.connectionTestTimeout = connectionTestTimeout;
+    }
+
+    /**
+     * @return how many seconds each connection test will wait for a response.
+     */
+    public int getConnectionTestTimeout() {
+        return connectionTestTimeout;
+    }
+
+    /**
+     * @return how many seconds each connection test will wait for a response,
+     * bounded above by the acquisition timeout.
+     */
+    public int getEffectiveConnectionTestTimeout() {
+        int t1 = getConnectionTestTimeout();
+        int t2 = getAcquisitionTimeout();
+
+        if ((t1 > 0) && (t2 > 0)) {
+            return Math.min(t1, t2);
+        } else {
+            return Math.max(t1, t2);
+        }
     }
 
     /**

--- a/btm/src/test/java/bitronix/tm/resource/jdbc/PoolingDataSourceTest.java
+++ b/btm/src/test/java/bitronix/tm/resource/jdbc/PoolingDataSourceTest.java
@@ -28,4 +28,33 @@ public class PoolingDataSourceTest extends TestCase {
         }
     }
 
+    public void testEffectiveConnectionTimeoutWhenSet() {
+        PoolingDataSource pds = new PoolingDataSource();
+        pds.setConnectionTestTimeout(10);
+        assertEquals(10, pds.getEffectiveConnectionTestTimeout());
+    }
+
+    public void testEffectiveConnectionTimeoutWhenAcquisitionTimeoutSet() {
+        PoolingDataSource pds = new PoolingDataSource();
+        pds.setAcquisitionTimeout(10);
+        assertEquals(10, pds.getEffectiveConnectionTestTimeout());
+    }
+
+    public void testEffectiveConnectionTimeoutIsMinimumValue() {
+        PoolingDataSource pds = new PoolingDataSource();
+
+        pds.setConnectionTestTimeout(5);
+        pds.setAcquisitionTimeout(10);
+        assertEquals(5, pds.getEffectiveConnectionTestTimeout());
+
+        pds.setAcquisitionTimeout(15);
+        pds.setConnectionTestTimeout(20);
+        assertEquals(15, pds.getEffectiveConnectionTestTimeout());
+    }
+
+    public void testDefaultEffectiveAcquisitionTimeout() {
+        PoolingDataSource pds = new PoolingDataSource();
+        assertEquals(30, pds.getEffectiveConnectionTestTimeout());
+    }
+
 }


### PR DESCRIPTION
Some databases (e.g. Oracle) can conceal multiple server nodes behind a single connection URL. So if we timeout while trying to connect to one node, we can still hope to connect to one of the other nodes. However, this assumes that the connection timeout is smaller than BTM's connection acquisition timeout.

Allow the connection test's timeout to be configured independently.
