### PR TITLE
Pluggable BTM context

### DIFF
--- a/btm/src/main/java/bitronix/tm/ServicesFactory.java
+++ b/btm/src/main/java/bitronix/tm/ServicesFactory.java
@@ -1,0 +1,104 @@
+package bitronix.tm;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.BitronixTransactionSynchronizationRegistry;
+import bitronix.tm.Configuration;
+import bitronix.tm.TransactionManagerServices;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import bitronix.tm.journal.DiskJournal;
+import bitronix.tm.journal.Journal;
+import bitronix.tm.journal.NullJournal;
+import bitronix.tm.recovery.Recoverer;
+import bitronix.tm.resource.ResourceLoader;
+import bitronix.tm.timer.TaskScheduler;
+import bitronix.tm.twopc.executor.AsyncExecutor;
+import bitronix.tm.twopc.executor.Executor;
+import bitronix.tm.twopc.executor.SyncExecutor;
+import bitronix.tm.utils.ClassLoaderUtils;
+import bitronix.tm.utils.DefaultExceptionAnalyzer;
+import bitronix.tm.utils.ExceptionAnalyzer;
+import bitronix.tm.utils.InitializationException;
+
+/**
+ * Factory of services.
+ */
+public class ServicesFactory {
+    private final static Logger log = LoggerFactory.getLogger(TransactionManagerServices.class);
+
+    public static BitronixTransactionManager crateTransactionManager() {
+        return new BitronixTransactionManager();
+    }
+
+    public static BitronixTransactionSynchronizationRegistry createTransactionSynchronizationRegistry() {
+        return new BitronixTransactionSynchronizationRegistry();
+    }
+
+    public static Configuration createConfiguration() {
+        return new Configuration();
+    }
+
+    public static Journal createJournal(Journal journal, String configuredJournal) throws InitializationException {
+        if ("null".equals(configuredJournal) || null == configuredJournal) {
+            journal = new NullJournal();
+        } else if ("disk".equals(configuredJournal)) {
+            journal = new DiskJournal();
+        } else {
+            try {
+                Class<?> clazz = ClassLoaderUtils.loadClass(configuredJournal);
+                journal = (Journal) clazz.newInstance();
+            } catch (Exception ex) {
+                throw new InitializationException("invalid journal implementation '" + configuredJournal + "'", ex);
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("using journal " + configuredJournal);
+        }
+        return journal;
+    }
+
+    public static TaskScheduler createTaskScheduler() {
+        return new TaskScheduler();
+    }
+
+    public static ResourceLoader createResourceLoader() {
+        return new ResourceLoader();
+    }
+
+    public static Recoverer createRecoverer() {
+        return new Recoverer();
+    }
+
+    public static Executor createExecutor(boolean isAsynchronouse2Pc) {
+        Executor executor;
+        if (isAsynchronouse2Pc) {
+            if (log.isDebugEnabled()) {
+                log.debug("using AsyncExecutor");
+            }
+            executor = new AsyncExecutor();
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("using SyncExecutor");
+            }
+            executor = new SyncExecutor();
+        }
+        return executor;
+    }
+
+    public static ExceptionAnalyzer createExceptionAnalyser(String exceptionAnalyzerName) {
+        ExceptionAnalyzer analyzer;
+        analyzer = new DefaultExceptionAnalyzer();
+        if (exceptionAnalyzerName != null) {
+            try {
+                analyzer = (ExceptionAnalyzer) ClassLoaderUtils.loadClass(exceptionAnalyzerName).newInstance();
+            } catch (Exception ex) {
+                log.warn("failed to initialize custom exception analyzer, using default one instead", ex);
+            }
+        }
+        return analyzer;
+    }
+
+
+}

--- a/btm/src/main/java/bitronix/tm/spi/BitronixContext.java
+++ b/btm/src/main/java/bitronix/tm/spi/BitronixContext.java
@@ -1,0 +1,87 @@
+package bitronix.tm.spi;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.BitronixTransactionSynchronizationRegistry;
+import bitronix.tm.Configuration;
+import bitronix.tm.journal.Journal;
+import bitronix.tm.recovery.Recoverer;
+import bitronix.tm.resource.ResourceLoader;
+import bitronix.tm.timer.TaskScheduler;
+import bitronix.tm.twopc.executor.Executor;
+import bitronix.tm.utils.ExceptionAnalyzer;
+
+/**
+ * Keeps services instances.
+ */
+public interface BitronixContext {
+    /**
+     * Create an initialized transaction manager.
+     * @return the transaction manager.
+     */
+    BitronixTransactionManager getTransactionManager();
+
+    /**
+     * Create the JTA 1.1 TransactionSynchronizationRegistry.
+     * @return the TransactionSynchronizationRegistry.
+     */
+    BitronixTransactionSynchronizationRegistry getTransactionSynchronizationRegistry();
+
+    /**
+     * Create the configuration of all the components of the transaction manager.
+     * @return the global configuration.
+     */
+    Configuration getConfiguration();
+
+    /**
+     * Create the transactions journal.
+     * @return the transactions journal.
+     */
+    Journal getJournal();
+
+    /**
+     * Create the task scheduler.
+     * @return the task scheduler.
+     */
+    TaskScheduler getTaskScheduler();
+
+    /**
+     * Create the resource loader.
+     * @return the resource loader.
+     */
+    ResourceLoader getResourceLoader();
+
+    /**
+     * Create the transaction recoverer.
+     * @return the transaction recoverer.
+     */
+    Recoverer getRecoverer();
+
+    /**
+     * Create the 2PC executor.
+     * @return the 2PC executor.
+     */
+    Executor getExecutor();
+
+    /**
+     * Create the exception analyzer.
+     * @return the exception analyzer.
+     */
+    ExceptionAnalyzer getExceptionAnalyzer();
+
+    /**
+     * Check if the transaction manager has started.
+     * @return true if the transaction manager has started.
+     */
+    boolean isTransactionManagerRunning();
+
+    /**
+     * Check if the task scheduler has started.
+     * @return true if the task scheduler has started.
+     */
+    boolean isTaskSchedulerRunning();
+
+    /**
+     * Clear services references. Called at the end of the shutdown procedure.
+     */
+    void clear();
+}

--- a/btm/src/main/java/bitronix/tm/spi/DefaultBitronixContext.java
+++ b/btm/src/main/java/bitronix/tm/spi/DefaultBitronixContext.java
@@ -1,0 +1,173 @@
+package bitronix.tm.spi;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.BitronixTransactionSynchronizationRegistry;
+import bitronix.tm.Configuration;
+import bitronix.tm.ServicesFactory;
+import bitronix.tm.journal.Journal;
+import bitronix.tm.recovery.Recoverer;
+import bitronix.tm.resource.ResourceLoader;
+import bitronix.tm.timer.TaskScheduler;
+import bitronix.tm.twopc.executor.Executor;
+import bitronix.tm.utils.ExceptionAnalyzer;
+
+/**
+ * Default context which keeps one instance of each service.
+ */
+public class DefaultBitronixContext implements BitronixContext {
+    private final Lock transactionManagerLock = new ReentrantLock();
+    private volatile BitronixTransactionManager transactionManager;
+
+    private final AtomicReference<BitronixTransactionSynchronizationRegistry> transactionSynchronizationRegistryRef = new AtomicReference<BitronixTransactionSynchronizationRegistry>();
+    private final AtomicReference<Configuration> configurationRef = new AtomicReference<Configuration>();
+    private final AtomicReference<Journal> journalRef = new AtomicReference<Journal>();
+    private final AtomicReference<TaskScheduler> taskSchedulerRef = new AtomicReference<TaskScheduler>();
+    private final AtomicReference<ResourceLoader> resourceLoaderRef = new AtomicReference<ResourceLoader>();
+    private final AtomicReference<Recoverer> recovererRef = new AtomicReference<Recoverer>();
+    private final AtomicReference<Executor> executorRef = new AtomicReference<Executor>();
+    private final AtomicReference<ExceptionAnalyzer> exceptionAnalyzerRef = new AtomicReference<ExceptionAnalyzer>();
+
+    @Override
+    public BitronixTransactionManager getTransactionManager() {
+        transactionManagerLock.lock();
+        try {
+            if (transactionManager == null) {
+                transactionManager = ServicesFactory.crateTransactionManager();
+            }
+            return transactionManager;
+        } finally {
+            transactionManagerLock.unlock();
+        }
+    }
+
+    @Override
+    public BitronixTransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
+        BitronixTransactionSynchronizationRegistry transactionSynchronizationRegistry = transactionSynchronizationRegistryRef.get();
+        if (transactionSynchronizationRegistry == null) {
+            transactionSynchronizationRegistry = ServicesFactory.createTransactionSynchronizationRegistry();
+            if (!transactionSynchronizationRegistryRef.compareAndSet(null, transactionSynchronizationRegistry)) {
+                transactionSynchronizationRegistry = transactionSynchronizationRegistryRef.get();
+            }
+        }
+        return transactionSynchronizationRegistry;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        Configuration configuration = configurationRef.get();
+        if (configuration == null) {
+            configuration = ServicesFactory.createConfiguration();
+            if (!configurationRef.compareAndSet(null, configuration)) {
+                configuration = configurationRef.get();
+            }
+        }
+        return configuration;
+    }
+
+    @Override
+    public Journal getJournal() {
+        Journal journal = journalRef.get();
+        if (journal == null) {
+            String configuredJournal = getConfiguration().getJournal();
+            journal = ServicesFactory.createJournal(journal, configuredJournal);
+
+            if (!journalRef.compareAndSet(null, journal)) {
+                journal = journalRef.get();
+            }
+        }
+        return journal;
+    }
+
+    @Override
+    public TaskScheduler getTaskScheduler() {
+        TaskScheduler taskScheduler = taskSchedulerRef.get();
+        if (taskScheduler == null) {
+            taskScheduler = ServicesFactory.createTaskScheduler();
+            if (!taskSchedulerRef.compareAndSet(null, taskScheduler)) {
+                taskScheduler = taskSchedulerRef.get();
+            } else {
+                taskScheduler.start();
+            }
+        }
+        return taskScheduler;
+    }
+
+    @Override
+    public ResourceLoader getResourceLoader() {
+        ResourceLoader resourceLoader = resourceLoaderRef.get();
+        if (resourceLoader == null) {
+            resourceLoader = ServicesFactory.createResourceLoader();
+            if (!resourceLoaderRef.compareAndSet(null, resourceLoader)) {
+                resourceLoader = resourceLoaderRef.get();
+            }
+        }
+        return resourceLoader;
+    }
+
+    @Override
+    public Recoverer getRecoverer() {
+        Recoverer recoverer = recovererRef.get();
+        if (recoverer == null) {
+            recoverer = ServicesFactory.createRecoverer();
+            if (!recovererRef.compareAndSet(null, recoverer)) {
+                recoverer = recovererRef.get();
+            }
+        }
+        return recoverer;
+    }
+
+    @Override
+    public Executor getExecutor() {
+        Executor executor = executorRef.get();
+        if (executor == null) {
+            executor = ServicesFactory.createExecutor(getConfiguration().isAsynchronous2Pc());
+            if (!executorRef.compareAndSet(null, executor)) {
+                executor.shutdown();
+                executor = executorRef.get();
+            }
+        }
+        return executor;
+    }
+
+    @Override
+    public ExceptionAnalyzer getExceptionAnalyzer() {
+        ExceptionAnalyzer analyzer = exceptionAnalyzerRef.get();
+        if (analyzer == null) {
+            String exceptionAnalyzerName = getConfiguration().getExceptionAnalyzer();
+            analyzer = ServicesFactory.createExceptionAnalyser(exceptionAnalyzerName);
+            if (!exceptionAnalyzerRef.compareAndSet(null, analyzer)) {
+                analyzer.shutdown();
+                analyzer = exceptionAnalyzerRef.get();
+            }
+        }
+        return analyzer;
+    }
+
+    @Override
+    public boolean isTransactionManagerRunning() {
+        return transactionManager != null;
+    }
+
+    @Override
+    public boolean isTaskSchedulerRunning() {
+        return taskSchedulerRef.get() != null;
+    }
+
+    @Override
+    public synchronized void clear() {
+        transactionManager = null;
+
+        transactionSynchronizationRegistryRef.set(null);
+        configurationRef.set(null);
+        journalRef.set(null);
+        taskSchedulerRef.set(null);
+        resourceLoaderRef.set(null);
+        recovererRef.set(null);
+        executorRef.set(null);
+        exceptionAnalyzerRef.set(null);
+    }
+}


### PR DESCRIPTION
Currently only one instance of BTM can exist in single classloader.
This is because class TransactionManagerServices keeps services instances
in static fields.

This commit adds BitronixContext which is responsible for keeping service
instances. The default implementation does not change any semantics.
Instances are still kept statically. But different BitronixContext
implementations can be selected by the user using ServiceLoader
infrastructure.