### PR TITLE
Add explicit JTA dependency to jetty6 and tomcat55 lifecycle

### DIFF
--- a/btm-jetty6-lifecycle/pom.xml
+++ b/btm-jetty6-lifecycle/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>jetty</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/btm-tomcat55-lifecycle/pom.xml
+++ b/btm-tomcat55-lifecycle/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>catalina</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Although an Eclipse build works fine, mvn clean install fails (for me at least) because the TransactionManager class is nog found. Looking at the dependency hierarchy there is indeed no dependency on the javax.transaction API. (This is because org.codehaus.btm:btm has declared the dependency as provided, which causes it not to be transitive)

This PR adds a explicit dependency to javax.transaction:jta to both lifecycle projects.