### PR TITLE
Add maven gpg plugin configuration

### DIFF
--- a/btm-jetty6-lifecycle/pom.xml
+++ b/btm-jetty6-lifecycle/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>jetty</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/btm-tomcat55-lifecycle/pom.xml
+++ b/btm-tomcat55-lifecycle/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>catalina</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,32 @@
 
     <profiles>
         <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>dist</id>
             <modules>
                 <module>btm-dist</module>


### PR DESCRIPTION
Add maven gpg plugin configuration for signing artifacts.

This is needed for publishing to Sonatype, see http://central.sonatype.org/pages/requirements.html and  http://central.sonatype.org/pages/working-with-pgp-signatures.html for more info.