### PR TITLE
Add ability to customize connection on lease and return to pool.

### DIFF
--- a/btm/src/main/java/bitronix/tm/resource/jdbc/ConnectionCustomizer.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/ConnectionCustomizer.java
@@ -31,6 +31,20 @@ public interface ConnectionCustomizer {
      * @param uniqueName the PoolingDataSource unique name.
      */
     public void onAcquire(Connection connection, String uniqueName);
+    
+    /**
+     * Called when the physical connection is leased from the pool.
+     * @param connection the physical connection.
+     * @param uniqueName the PoolingDataSource unique name.
+     */
+    public void onLease(Connection connection, String uniqueName);
+    
+    /**
+     * Called when the physical connection is returned to the pool.
+     * @param connection the physical connection.
+     * @param uniqueName the PoolingDataSource unique name.
+     */
+    public void onRelease(Connection connection, String uniqueName);
 
     /**
      * Called when the physical connection is destroyed.

--- a/btm/src/main/java/bitronix/tm/resource/jdbc/JdbcPooledConnection.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/JdbcPooledConnection.java
@@ -226,6 +226,7 @@ public class JdbcPooledConnection extends AbstractXAResourceHolder<JdbcPooledCon
             // Only requeue a connection if it is no longer in use.  In the case of non-shared connections,
             // usageCount will always be 0 here, so the default behavior is unchanged.
             if (usageCount == 0) {
+                poolingDataSource.fireOnRelease(connection);
                 try {
                     TransactionContextHelper.requeue(this, poolingDataSource);
                 } catch (BitronixSystemException ex) {
@@ -309,6 +310,8 @@ public class JdbcPooledConnection extends AbstractXAResourceHolder<JdbcPooledCon
         }
 
         if (log.isDebugEnabled()) { log.debug("got connection handle from " + this); }
+        poolingDataSource.fireOnLease(connection);
+        
         return getConnectionHandle(connection);
     }
 

--- a/btm/src/main/java/bitronix/tm/resource/jdbc/PoolingDataSource.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/PoolingDataSource.java
@@ -279,6 +279,26 @@ public class PoolingDataSource extends ResourceBean implements DataSource, XARes
         }
     }
 
+    void fireOnLease(Connection connection){
+        for (ConnectionCustomizer connectionCustomizer : connectionCustomizers) {
+            try {
+                connectionCustomizer.onLease(connection, getUniqueName());
+            } catch (Exception ex){
+                log.warn("ConnectionCustomizer.onLease() failed for " + connectionCustomizer, ex);
+            }
+        }
+    }
+
+    void fireOnRelease(Connection connection){
+        for (ConnectionCustomizer connectionCustomizer : connectionCustomizers) {
+            try {
+                connectionCustomizer.onRelease(connection, getUniqueName());
+            } catch (Exception ex){
+                log.warn("ConnectionCustomizer.onRelease() failed for " + connectionCustomizer, ex);
+            }
+        }
+    }
+
     void fireOnDestroy(Connection connection) {
         for (ConnectionCustomizer connectionCustomizer : connectionCustomizers) {
             try {
@@ -288,7 +308,6 @@ public class PoolingDataSource extends ResourceBean implements DataSource, XARes
             }
         }
     }
-
 
     /* Implementation of DataSource interface */
     @Override

--- a/btm/src/test/java/bitronix/tm/resource/jdbc/ConnectionCustomizerTest.java
+++ b/btm/src/test/java/bitronix/tm/resource/jdbc/ConnectionCustomizerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2006-2013 Bitronix Software (http://www.bitronix.be)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bitronix.tm.resource.jdbc;
+
+import bitronix.tm.resource.jdbc.PoolingDataSource;
+import bitronix.tm.mock.resource.jdbc.MockitoXADataSource;
+
+import java.sql.Connection;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.mockito.Mockito.*;
+
+public class ConnectionCustomizerTest {
+    private ConnectionCustomizer customizer;
+
+    @Before public void setup(){
+        customizer = mock(ConnectionCustomizer.class);
+    }
+
+    @Test public void testCustomizerCall() throws Exception{
+        String name = "pds";
+        PoolingDataSource pds = new PoolingDataSource();
+        pds.setUniqueName(name);
+        pds.setXaDataSource(new MockitoXADataSource());
+        pds.setMinPoolSize(1);
+        pds.setMaxPoolSize(1);
+        pds.setXaDataSource(new MockitoXADataSource());
+        pds.addConnectionCustomizer(customizer);
+        pds.init();
+
+        Connection connection = pds.getConnection(); // onAcquire, onLease
+        connection.close(); // onRelease
+
+        connection = pds.getConnection(); // onLease
+        connection.close(); // onRelease
+
+        pds.close(); // onDestroy
+
+        InOrder callOrder = inOrder(customizer);
+        callOrder.verify(customizer).onAcquire(any(Connection.class), eq(name));
+        callOrder.verify(customizer).onLease(any(Connection.class), eq(name));
+        callOrder.verify(customizer).onRelease(any(Connection.class), eq(name));
+        callOrder.verify(customizer).onLease(any(Connection.class), eq(name));
+        callOrder.verify(customizer).onRelease(any(Connection.class), eq(name));
+        callOrder.verify(customizer).onDestroy(any(Connection.class), eq(name));
+    }
+}


### PR DESCRIPTION
This patch adds two additional connection customization hooks to `JdbcPooledConnection`.

* `onLease` - fired when a connection is leased out of the pool.
* `onRelease` - fired when the connection is returned to the pool.

Typical use case of these entry points would be to meter connection usage.

A good example for DB2 would be to turn on DB2SystemMonitor only during connection usage facilitating resource usage monitor to reflect actual usage timings excluding pool wait time.

```
public void onLease(Connection connection, String uniqueName) {
    DB2Connection db2Connection = (DB2Connection) connection;
    db2Connection.getDB2SystemMonitor().enable(true);
    db2Connection.getDB2SystemMonitor().start(DB2SystemMonitor.RESET_TIMES);
}

public void onRelease(Connection connection, String uniqueName) {
    DB2Connection db2Connection = (DB2Connection) connection;
    DB2SystemMonitor sysMonitor = db2Connection.getDB2SystemMonitor();
    sysMonitor.stop();
}
``` 

Please review.