### PR TITLE
Btm 2.1.x masks original SQLException

### DIFF
--- a/btm-dist/pom.xml
+++ b/btm-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>btm-dist</artifactId>
     <packaging>pom</packaging>

--- a/btm-dist/pom.xml
+++ b/btm-dist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
     </parent>
     <artifactId>btm-dist</artifactId>
     <packaging>pom</packaging>

--- a/btm-jetty6-lifecycle/pom.xml
+++ b/btm-jetty6-lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>btm-jetty6-lifecycle</artifactId>
     <name>Bitronix Transaction Manager :: Jetty 6 lifecycle</name>

--- a/btm-jetty6-lifecycle/pom.xml
+++ b/btm-jetty6-lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
     </parent>
     <artifactId>btm-jetty6-lifecycle</artifactId>
     <name>Bitronix Transaction Manager :: Jetty 6 lifecycle</name>

--- a/btm-jetty7-lifecycle/pom.xml
+++ b/btm-jetty7-lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>btm-jetty7-lifecycle</artifactId>
     <name>Bitronix Transaction Manager :: Jetty 7 lifecycle</name>

--- a/btm-jetty7-lifecycle/pom.xml
+++ b/btm-jetty7-lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
     </parent>
     <artifactId>btm-jetty7-lifecycle</artifactId>
     <name>Bitronix Transaction Manager :: Jetty 7 lifecycle</name>

--- a/btm-tomcat55-lifecycle/pom.xml
+++ b/btm-tomcat55-lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
     </parent>
     <artifactId>btm-tomcat55-lifecycle</artifactId>
     <name>Bitronix Transaction Manager :: Tomcat 5.5+ lifecycle</name>

--- a/btm-tomcat55-lifecycle/pom.xml
+++ b/btm-tomcat55-lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>btm-tomcat55-lifecycle</artifactId>
     <name>Bitronix Transaction Manager :: Tomcat 5.5+ lifecycle</name>

--- a/btm/pom.xml
+++ b/btm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3-SNAPSHOT</version>
+        <version>2.1.3</version>
     </parent>
     <groupId>org.codehaus.btm</groupId>
     <artifactId>btm</artifactId>

--- a/btm/pom.xml
+++ b/btm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm-parent</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4-SNAPSHOT</version>
     </parent>
     <groupId>org.codehaus.btm</groupId>
     <artifactId>btm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.codehaus.btm</groupId>
     <artifactId>btm-parent</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.1.3</version>
     <packaging>pom</packaging>
     <name>Bitronix Transaction Manager</name>
     <inceptionYear>2006</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.codehaus.btm</groupId>
     <artifactId>btm-parent</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Bitronix Transaction Manager</name>
     <inceptionYear>2006</inceptionYear>


### PR DESCRIPTION
The current implementation doesn’t log the original cause (SQLException) if errors occurs during “auto commit” handling. Further investigations has shown that this is limited to LrcXAResource.