### PR TITLE
Use geronimo-jta dependency instead of javax.transaction

### DIFF
--- a/btm-dist/pom.xml
+++ b/btm-dist/pom.xml
@@ -58,8 +58,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>jta</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/btm-docs/src/main/asciidoc/Configuration2x.adoc
+++ b/btm-docs/src/main/asciidoc/Configuration2x.adoc
@@ -185,4 +185,19 @@ See also https://github.com/bitronix/btm/blob/master/btm/src/main/java/bitronix/
 [[pools]]
 == Connection pools settings
 
-JDBC and JMS connection pools configuration are discussed in details in the JDBC pools configuration and the JMS pools configuration pages. Alternatively you can use the Resource Loader instead. 
+JDBC and JMS connection pools configuration are discussed in details in the JDBC pools configuration and the JMS pools configuration pages. Alternatively you can use the Resource Loader instead.
+
+[[osgi]]
+== OSGi settings
+
+When deployed to an OSGi container, the transaction manager will be started automatically (default). You can use following interfaces to get a service reference to the running transaction manager:
+
+    javax.transaction.TransactionManager
+    javax.transaction.UserTransaction
+
+During startup, the bundle activator will look for a configuration file in the configuration area of the bundle. If `bitronix.tm.configuration` has not been specified, the activator will search for a file named `bitronix-default-config.properties`. If the bundles configuration area does not contain such a file, the activator tries to load the configuration directly from the path specified. If the file does not exist, an InitializationException will be caused to be thrown.
+
+If `bitronix.tm.resource.configuration` is specified, the activator will lookup the resource configuration in the same manner; it firstly checks the bundles configuration area. If the file could not be found, the activator tries to load it directly from the file system. If the file does not exist, an InitializationException will be caused to be thrown.
+
+
+

--- a/btm-jetty6-lifecycle/pom.xml
+++ b/btm-jetty6-lifecycle/pom.xml
@@ -15,8 +15,8 @@
             <artifactId>btm</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>jta</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/btm-spring/pom.xml
+++ b/btm-spring/pom.xml
@@ -16,8 +16,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>jta</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/btm-tomcat55-lifecycle/pom.xml
+++ b/btm-tomcat55-lifecycle/pom.xml
@@ -15,8 +15,8 @@
             <artifactId>btm</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>jta</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/btm/pom.xml
+++ b/btm/pom.xml
@@ -13,8 +13,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>jta</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -182,7 +182,6 @@ public final class Version {
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-Activator>bitronix.tm.osgi.Activator</Bundle-Activator>
                         <Bundle-SymbolicName>bitronix.tm</Bundle-SymbolicName>
                         <Export-Package>bitronix.tm,bitronix.tm.utils,bitronix.tm.resource.jdbc</Export-Package>
                         <Import-Package>
@@ -192,7 +191,8 @@ public final class Version {
                             org.slf4j,
                             javax.crypto,javax.crypto.spec,
                             javax.jms,javax.management,javax.naming,javax.naming.spi,javax.rmi,javax.sql,
-                            javax.transaction,javax.transaction.xa,
+                            javax.transaction,
+                            javax.transaction.xa,
                             javax.swing;resolution:=optional,
                             javax.swing.border;resolution:=optional,
                             javax.swing.event;resolution:=optional,

--- a/btm/src/test/java/bitronix/tm/osgi/ActivatorTest.java
+++ b/btm/src/test/java/bitronix/tm/osgi/ActivatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 Roland Hauser, <sourcepond@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bitronix.tm.osgi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+import bitronix.tm.BitronixTransactionManager;
+import bitronix.tm.TransactionManagerServices;
+
+/**
+ * @author rolandhauser
+ *
+ */
+public class ActivatorTest {
+	private static File CONFIG_AREA = new File("src/test/resources");
+	private final BitronixTransactionManager tm = TransactionManagerServices.getTransactionManager();
+	private final ServiceRegistration tmRegistration = mock(ServiceRegistration.class);
+	private final ServiceRegistration utRegistration = mock(ServiceRegistration.class);
+	private final BundleContext context = mock(BundleContext.class);
+	private final Activator activator = new Activator();
+
+	@Before
+	public void setup() {
+		when(context.getProperty("osgi.configuration.area")).thenReturn(CONFIG_AREA.toURI().toString());
+		when(context.registerService(TransactionManager.class.getName(), tm, null)).thenReturn(tmRegistration);
+		when(context.registerService(UserTransaction.class.getName(), tm, null)).thenReturn(utRegistration);
+	}
+
+	@After
+	public void tearDown() {
+		tm.shutdown();
+	}
+	
+	@Test
+	public void startStop() throws Exception {
+		activator.start(context);
+		assertEquals(new File(CONFIG_AREA, "bitronix-default-config.properties").getAbsolutePath(),
+				System.getProperty("bitronix.tm.configuration"));
+		assertNull(System.getProperty("bitronix.tm.resource.configuration"));
+		verify(context).registerService(TransactionManager.class.getName(), tm, null);
+		verify(context).registerService(UserTransaction.class.getName(), tm, null);
+		
+		activator.stop(context);
+		verify(tmRegistration).unregister();
+		verify(utRegistration).unregister();
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,9 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.transaction</groupId>
-                <artifactId>jta</artifactId>
-                <version>1.1</version>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-jta_1.1_spec</artifactId>
+                <version>1.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
This allows the maven-bundle-plugin to generate proper versions for
imported packages because geronimo-jta itself is an OSGi bundle.
Additionally, added a unit test for Activator and extended documentation
a bit.